### PR TITLE
Fix build script reference

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -71,6 +71,6 @@
 
   </div>
 
-  <script src="dist/bundle.js" defer></script>
+  <script src="scripts/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reference `scripts/main.js` in `src/index.html` so `build.js` can inline it

## Testing
- `npm run build` *(fails: rollup not found)*
- `node build.js`

------
https://chatgpt.com/codex/tasks/task_e_685ba629aea883318748d832f49fd7b1