### PR TITLE
Add CONTRIBUTING guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to Erin's Coffee Grinder
+
+Thanks for your interest in contributing! The following guidelines will help you get started.
+
+## Getting Started
+
+1. **Fork** the repository and create your feature branch from `main`.
+2. Run the project locally with:
+   ```bash
+   npm run dev
+   ```
+3. Ensure the build succeeds:
+   ```bash
+   npm run build
+   node build.js
+   ```
+
+## Making Changes
+
+- Keep pull requests focused and well described.
+- Follow existing code style and structure.
+- Update documentation when applicable.
+
+## Submitting Changes
+
+1. Commit your work with clear messages.
+2. Push the branch to your fork and open a pull request.
+3. The maintainers will review and provide feedback.
+
+Thank you for helping improve this project!

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Build artifacts are generated in `dist/`:
    ```
 
 ## Contributing
-Please see `CONTRIBUTING.md` for guidelines.
+Contributions are welcome! Fork the repository and create a feature branch
+from `main`. When you're ready, open a pull request. See
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for full guidelines.
 
 ## License
 This project is licensed under the MIT License.


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` with basic workflow
- update README contribution section to point to the file

## Testing
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb44557ec8331b012507fd9f78dca