### PR TITLE
Fix sanitizeForHTML escaping

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -85,7 +85,12 @@ function clearAllErrors() {
 }
 function sanitizeForHTML(str) {
     if (!str) return '';
-    return String(str).replace(/&/g, '&').replace(/</g, '<').replace(/>/g, '>').replace(/"/g, '"').replace(/'/g, '&#039;');
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
 }
 function formatJson(data) {
     try {
@@ -435,4 +440,8 @@ function download(filename, content) {
 // Try to validate if there's content on load (e.g., from browser cache)
 if (editor.getValue().trim()) {
     tryValidate();
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { sanitizeForHTML };
 }

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,11 @@
+const { sanitizeForHTML } = require('../src/scripts/main');
+
+describe('sanitizeForHTML (main)', () => {
+  test('escapes HTML characters', () => {
+    expect(sanitizeForHTML("<div>&\"'")).toBe('&lt;div&gt;&amp;&quot;&#039;');
+  });
+
+  test('returns empty string for nullish input', () => {
+    expect(sanitizeForHTML(null)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- fix sanitizeForHTML in main.js to escape special characters
- expose sanitizeForHTML from main.js for tests
- add unit tests for main.js version of sanitizeForHTML

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npx jest tests/main.test.js tests/worker.test.js` *(fails: Could not download Jest)*

------
https://chatgpt.com/codex/tasks/task_e_685bba1c588c8331aec24ade24a51797