### PR TITLE
Fix stray backtick in generatePlain

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -404,8 +404,8 @@ function generatePlain() {
          txt += "## Module Details\n";
          processedModules.forEach(m => {
              let indent = '  '.repeat(m.level);
-             let pathDisplay = m.path.replace(/ > $/, '').replace(/\[Router (\d+)\]/g, 'R$1').replace(/\[Error Handler for (\d+)\]/g, 'Err$1');
-txt += `${indent}[${m.id}] ${pathDisplay ? pathDisplay + ' -> ' : ''}${m.app}:${m.action}\`;`;
+            let pathDisplay = m.path.replace(/ > $/, '').replace(/\[Router (\d+)\]/g, 'R$1').replace(/\[Error Handler for (\d+)\]/g, 'Err$1');
+            txt += `${indent}[${m.id}] ${pathDisplay ? pathDisplay + ' -> ' : ''}${m.app}:${m.action}`;
              if (m.label) txt += ` (${m.label})`;
              txt += `\n`;
              if (m.connectionLabel !== 'N/A') txt += `${indent}  Connection: ${m.connectionLabel} (${m.connectionType})\n`;


### PR DESCRIPTION
## Summary
- fix a stray backtick in the `generatePlain` function

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685bba2412788331b30f031a05f3a8d0