### PR TITLE
Fix build worker injection

### DIFF
--- a/build.js
+++ b/build.js
@@ -41,7 +41,8 @@ let output = htmlContent.replace(
 const workerVar = `const WORKER_CODE = \`${workerJsContent.replace(/`/g, '\\`')}\`;`;
 output = output.replace(
   /<script src="scripts\/main.js"><\/script>/,
-
+  `<script>\n${workerVar}\n${mainJsContent}\n<\/script>`
+);
 
 fs.writeFileSync(outputFile, output, 'utf-8');
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Transform automation blueprints into readable documentation",
   "main": "src/index.html",
   "scripts": {
-    "dev": "python -m http.server 8080 --directory src",
+    "dev": "python -m http.server 8080 --directory src"
   },
   "keywords": [
     "automation",


### PR DESCRIPTION
## Summary
- ensure package.json is valid JSON
- inline main.js and worker script in build.js

## Testing
- `node build.js`
- `npx jest` *(fails: 403 Forbidden for npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685bba27e35c8331a889f815e4f1baf7