### PR TITLE
Expose formatJson helper in worker

### DIFF
--- a/src/scripts/worker.js
+++ b/src/scripts/worker.js
@@ -8,6 +8,24 @@ function sanitizeForHTML(str) {
         .replace(/'/g, '&#039;');
 }
 
+// Fallback helper in case utils cannot be loaded (browser worker environment)
+let formatJson = function (data) {
+    try {
+        return JSON.stringify(data, null, 2);
+    } catch (e) {
+        return '[Could not format JSON]';
+    }
+};
+
+// Use shared implementation when running under Node for tests
+if (typeof module !== 'undefined' && module.exports) {
+    try {
+        ({ formatJson } = require('./utils'));
+    } catch (_) {
+        // ignore, fallback to local implementation
+    }
+}
+
 if (typeof self !== 'undefined') {
 self.onmessage = e => {
   const { blueprint, toggles } = e.data;
@@ -253,5 +271,5 @@ self.onmessage = e => {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { sanitizeForHTML };
+  module.exports = { sanitizeForHTML, formatJson };
 }

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -1,4 +1,4 @@
-const { sanitizeForHTML } = require('../src/scripts/worker');
+const { sanitizeForHTML, formatJson } = require('../src/scripts/worker');
 
 describe('sanitizeForHTML', () => {
   test('escapes HTML characters', () => {
@@ -7,5 +7,18 @@ describe('sanitizeForHTML', () => {
 
   test('returns empty string for nullish input', () => {
     expect(sanitizeForHTML(null)).toBe('');
+  });
+});
+
+describe('formatJson (worker)', () => {
+  test('pretty prints objects', () => {
+    const obj = { a: 1 };
+    expect(formatJson(obj)).toBe('{\n  "a": 1\n}');
+  });
+
+  test('handles circular structures gracefully', () => {
+    const a = {};
+    a.self = a;
+    expect(formatJson(a)).toBe('[Could not format JSON]');
   });
 });


### PR DESCRIPTION
## Summary
- add a `formatJson` helper to `worker.js`
- re-export `formatJson` for tests
- test `formatJson` through `worker.test.js`

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685bbf5f3cf88331b5b2785a14418e62