### PR TITLE
Add npm script commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Transform automation blueprints into readable documentation",
   "main": "src/index.html",
   "scripts": {
+    "dev": "python -m http.server 8080 --directory src",
+    "build": "rollup -c build.config.mjs",
+    "serve": "npx serve dist -p 8080",
+    "test": "jest"
   },
   "keywords": [
     "automation",


### PR DESCRIPTION
## Summary
- define dev, build, serve, and test scripts in package.json

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('package.json'))"`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbf5f5f20833183b6e2357ddd0356