### PR TITLE
Update .gitignore with coverage and logs folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 dist/
 .DS_Store
+coverage/
+logs/
 *.log
 .env


### PR DESCRIPTION
## Summary
- extend `.gitignore` to exclude `coverage/` and `logs/`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7f1097d08331860bed2b75ebcdb9