### PR TITLE
Fix worker test imports

### DIFF
--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -1,4 +1,4 @@
-
+const { sanitizeForHTML, formatJson } = require('../src/scripts/worker');
 describe('sanitizeForHTML', () => {
   test('escapes HTML characters', () => {
     expect(sanitizeForHTML("<div>&\"'")).toBe('&lt;div&gt;&amp;&quot;&#039;');


### PR DESCRIPTION
## Summary
- ensure worker tests load helper functions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7f0f3d3883318ca281cc1ae62116