### PR TITLE
Fix inline module replacement

### DIFF
--- a/build.js
+++ b/build.js
@@ -40,8 +40,8 @@ let output = htmlContent.replace(
 // Inline main.js and provide worker code variable for offline build
 const workerVar = `const WORKER_CODE = \`${workerJsContent.replace(/`/g, '\\`')}\`;`;
 output = output.replace(
-  /<script src="scripts\/main.js"><\/script>/,
-  `<script>\n${workerVar}\n${mainJsContent}\n<\/script>`
+  /<script type="module" src="scripts\/main.js"><\/script>/,
+  `<script type="module">\n${workerVar}\n${mainJsContent}\n<\/script>`
 );
 
 fs.writeFileSync(outputFile, output, 'utf-8');


### PR DESCRIPTION
## Summary
- look for `<script type="module" src="scripts/main.js"></script>` when inlining main.js
- output an inline module block with `WORKER_CODE` and main.js content

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ded3764b8833185b3d1d981edf353