### PR TITLE
Fix duplicate .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,4 @@ coverage/
 logs/
 *.log
 .env
-coverage/
-logs/
 .nyc_output/


### PR DESCRIPTION
## Summary
- remove repeated `coverage/` and `logs/` entries from `.gitignore`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ded88e1248331be5a51cef707b0aa