### PR TITLE
Fix worker tests import

### DIFF
--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -1,3 +1,5 @@
+const { sanitizeForHTML, formatJson } = require('../src/scripts/worker');
+
 describe('sanitizeForHTML', () => {
   test('escapes HTML characters', () => {
     expect(sanitizeForHTML("<div>&\"'")).toBe('&lt;div&gt;&amp;&quot;&#039;');


### PR DESCRIPTION
## Summary
- import sanitizeForHTML and formatJson in `worker.test.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ded89617883318b2ef6a5add1d5c5