### PR TITLE
Rename worker and export processBlueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [7.0.0-baseline] - 2025-06-25
 ### Added
 - Initial modularization of Coffee Grinder into separate HTML, CSS, and JavaScript files under `src/`.
-- Web worker extracted into `src/scripts/worker.js`.
+- Web worker extracted into `src/workers/specWorker.js`.
 - Build pipeline using Rollup (`build.config.js`) and a custom Node build script (`build.js`) to produce a single-file distribution in `dist/`.
 - Development scripts in `package.json` for serving the modular code and building the bundled release.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Erin's Coffee Grinder is a web-based blueprint analyzer that processes automatio
 - `src/index.html`: Main HTML file referencing external CSS and JS.
 - `src/styles/main.css`: Stylesheet extracted from original single-file app.
 - `src/scripts/main.js`: Main JavaScript logic for UI and blueprint processing.
-- `src/scripts/worker.js`: Web worker script for blueprint processing.
+- `src/workers/specWorker.js`: Web worker script for blueprint processing.
 - `.gitignore`: Specifies files and folders to ignore in Git.
 
 ## Getting Started

--- a/build.config.mjs
+++ b/build.config.mjs
@@ -17,7 +17,7 @@ export default [
     plugins: [resolve(), commonjs()]
   },
   {
-    input: 'src/scripts/worker.js',
+    input: 'src/workers/specWorker.js',
     output: {
       file: 'dist/worker.bundle.js',
       format: 'iife',

--- a/build.js
+++ b/build.js
@@ -12,7 +12,7 @@ if (!fs.existsSync(distDir)) {
 const htmlPath = path.join(srcDir, 'index.html');
 const cssPath = path.join(srcDir, 'styles', 'main.css');
 const mainJsPath = path.join(srcDir, 'scripts', 'main.js');
-const workerJsPath = path.join(srcDir, 'scripts', 'worker.js');
+const workerJsPath = path.join(srcDir, 'workers', 'specWorker.js');
 
 const htmlContent = fs.readFileSync(htmlPath, 'utf-8');
 const cssContent = fs.readFileSync(cssPath, 'utf-8');
@@ -21,7 +21,7 @@ const workerJsContent = fs.readFileSync(workerJsPath, 'utf-8');
 
 // Detect if the developer version already inlines the worker using a Blob
 const blobWorkerRegex = /new\s+Worker\(\s*URL\.createObjectURL\(\s*new\s+Blob/;
-const externalWorkerRegex = /const\s+specWorker\s*=\s*new\s+Worker\(['"]scripts\/worker\.js['"]\);/;
+const externalWorkerRegex = /const\s+specWorker\s*=\s*new\s+Worker\(['"]workers\/specWorker\.js['"]\);/;
 
 if (!blobWorkerRegex.test(mainJsContent) && externalWorkerRegex.test(mainJsContent)) {
   const workerBlobCode = `

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -161,7 +161,7 @@ function initWorker() {
     if (typeof WORKER_CODE !== 'undefined') {
         codePromise = Promise.resolve(WORKER_CODE);
     } else {
-        codePromise = fetch('scripts/worker.js').then(r => r.text());
+        codePromise = fetch('workers/specWorker.js').then(r => r.text());
     }
 
     return codePromise

--- a/src/workers/specWorker.js
+++ b/src/workers/specWorker.js
@@ -1,7 +1,7 @@
 let sanitizeForHTML, formatJson;
 
 if (typeof module !== 'undefined' && module.exports) {
-  ({ sanitizeForHTML, formatJson } = require('./utils'));
+  ({ sanitizeForHTML, formatJson } = require('../scripts/utils'));
 } else {
   sanitizeForHTML = str => {
     if (!str) return '';
@@ -22,13 +22,11 @@ if (typeof module !== 'undefined' && module.exports) {
   };
 }
 
-if (typeof self !== 'undefined') {
-self.onmessage = e => {
-  const { blueprint, toggles } = e.data;
+function processBlueprint(blueprint, toggles = {}) {
   let processedModules = [];
   let warnings = [];
 
-  function findConnectionDetails(connId, blueprint) {
+  function findConnectionDetails(connId) {
       if (!blueprint.connections || !connId) return { type: 'N/A', label: 'N/A (No ID)' };
       const conn = blueprint.connections.find(c => c.id === connId);
       return conn ? { type: conn.type || '?', label: conn.name || '?' } : { type: '?', label: `Not Found (ID: ${connId})` };
@@ -39,7 +37,7 @@ self.onmessage = e => {
       return moduleData.label || (moduleData.metadata && moduleData.metadata.label) || '';
   }
 
-   function getConnectionInfo(moduleData, blueprint) {
+   function getConnectionInfo(moduleData) {
       let connLabel = 'N/A';
       let connType = 'N/A';
       let connId = null;
@@ -261,10 +259,16 @@ self.onmessage = e => {
        html += '<div class="panel"><h3>Module Details</h3><p><em>No modules found or processed in the blueprint flow.</em></p></div>';
   }
 
-  postMessage({ html: html, warnings: warnings, processedModules: processedModules });
+  return { html: html, warnings: warnings, processedModules: processedModules };
 }
+
+if (typeof self !== 'undefined') {
+  self.onmessage = e => {
+    const { blueprint, toggles } = e.data;
+    postMessage(processBlueprint(blueprint, toggles));
+  };
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { sanitizeForHTML, formatJson };
+  module.exports = { sanitizeForHTML, formatJson, processBlueprint };
 }

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -1,4 +1,4 @@
-const { sanitizeForHTML, formatJson } = require('../src/scripts/worker');
+const { sanitizeForHTML, formatJson, processBlueprint } = require('../src/workers/specWorker');
 
 describe('sanitizeForHTML', () => {
   test('escapes HTML characters', () => {
@@ -20,5 +20,15 @@ describe('formatJson (worker)', () => {
     const a = {};
     a.self = a;
     expect(formatJson(a)).toBe('[Could not format JSON]');
+  });
+});
+
+describe('processBlueprint', () => {
+  test('returns result object with expected fields', () => {
+    const bp = { name: 'BP', flow: [] };
+    const result = processBlueprint(bp, {});
+    expect(result).toHaveProperty('html');
+    expect(result).toHaveProperty('warnings');
+    expect(result).toHaveProperty('processedModules');
   });
 });


### PR DESCRIPTION
## Summary
- rename worker.js -> workers/specWorker.js and export `processBlueprint`
- update build scripts, config, and imports
- update README and CHANGELOG for new path
- adapt tests for renamed file and new function

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685df02504e48331acc51cf87dd1d3f0