### PR TITLE
Add Rollup path aliases

### DIFF
--- a/build.config.mjs
+++ b/build.config.mjs
@@ -4,6 +4,18 @@
 
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import alias from '@rollup/plugin-alias';
+
+const pathAliases = alias({
+  entries: [
+    { find: '@components', replacement: 'src/components' },
+    { find: '@services', replacement: 'src/services' },
+    { find: '@workers', replacement: 'src/workers' },
+    { find: '@validators', replacement: 'src/validators' },
+    { find: '@utils', replacement: 'src/utils' },
+    { find: '@templates', replacement: 'src/templates' }
+  ]
+});
 
 export default [
   {
@@ -14,7 +26,7 @@ export default [
       name: 'CoffeeGrinderApp',
       sourcemap: true,
     },
-    plugins: [resolve(), commonjs()]
+    plugins: [pathAliases, resolve(), commonjs()]
   },
   {
     input: 'src/workers/specWorker.js',
@@ -24,6 +36,6 @@ export default [
       name: 'CoffeeGrinderWorker',
       sourcemap: true,
     },
-    plugins: [resolve(), commonjs()]
+    plugins: [pathAliases, resolve(), commonjs()]
   }
 ];

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-alias": "^5.0.0",
     "rollup": "^4.44.0",
     "jest": "^29.7.0"
   }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,6 +1,6 @@
-import { showError, showWarning, clearError, clearAllErrors } from '../components/ui/modals.js';
-import { activateExportButtons, generatePdf, download } from '../components/ui/buttons.js';
-import { setupTableFilter, makeSortable } from '../components/ui/tables.js';
+import { showError, showWarning, clearError, clearAllErrors } from '@components/ui/modals.js';
+import { activateExportButtons, generatePdf, download } from '@components/ui/buttons.js';
+import { setupTableFilter, makeSortable } from '@components/ui/tables.js';
 // --- Config & Initialization ---
 const META_FIELDS = ['preparedBy', 'recipient', 'version', 'objective'];
 const TOGGLE_FIELDS = ['showScenario', 'showConnections', 'showVars', 'showFilters', 'showModuleDetails'];


### PR DESCRIPTION
## Summary
- add @rollup/plugin-alias dependency
- configure Rollup with path aliases for source folders
- update UI imports to use the new alias paths

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df487139c8331bd70a721e1a68918