### PR TITLE
Add simple architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Erin's Coffee Grinder is a web-based blueprint analyzer that processes automatio
 - `src/workers/specWorker.js`: Web worker script for blueprint processing.
 - `.gitignore`: Specifies files and folders to ignore in Git.
 
+### Architecture Diagram
+For a quick overview of the folder layout, see [docs/arch.svg](docs/arch.svg).
+
 ## Getting Started
 
 ### Prerequisites

--- a/docs/arch.svg
+++ b/docs/arch.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" font-family="monospace" font-size="14">
+  <text x="10" y="20">src/</text>
+  <text x="30" y="40">components/</text>
+  <text x="50" y="60">ui/</text>
+  <text x="30" y="80">services/</text>
+  <text x="30" y="100">workers/</text>
+  <text x="30" y="120">validators/</text>
+  <text x="30" y="140">utils/</text>
+  <text x="30" y="160">templates/</text>
+  <text x="10" y="180">tests/</text>
+</svg>


### PR DESCRIPTION
## Summary
- add docs folder with arch.svg diagram
- link the diagram in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f8b6d00d88331baf2466be300f9ed