### PR TITLE
Add Make blueprint schema and importer/exporter utilities

### DIFF
--- a/docs/schemaCoverage.md
+++ b/docs/schemaCoverage.md
@@ -1,0 +1,9 @@
+# Schema Coverage
+
+The `makeBlueprintSchema.js` file captures the core parts of a Make blueprint. It defines objects for modules, routes, connections and variables. The schema aims to cover the following sections of the Make JSON format:
+
+- Scenario metadata including execution flags
+- Connection and variable definitions
+- Module layout with routes and error handlers
+
+Only commonly used fields are described. Custom metadata and uncommon properties are allowed by the schema using `additionalProperties: true`.

--- a/src/schemas/makeBlueprintSchema.js
+++ b/src/schemas/makeBlueprintSchema.js
@@ -1,0 +1,87 @@
+const schema = {
+  type: 'object',
+  required: ['name', 'flow'],
+  properties: {
+    name: { type: 'string' },
+    metadata: {
+      type: 'object',
+      properties: {
+        instant: { type: 'boolean' },
+        scenario: {
+          type: 'object',
+          properties: {
+            sequential: { type: 'boolean' }
+          },
+          required: ['sequential'],
+          additionalProperties: true
+        }
+      },
+      additionalProperties: true
+    },
+    connections: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id'],
+        properties: {
+          id: { anyOf: [{ type: 'integer' }, { type: 'string' }] },
+          name: { type: 'string' },
+          type: { type: 'string' }
+        },
+        additionalProperties: true
+      }
+    },
+    variables: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['name', 'type'],
+        properties: {
+          name: { type: 'string' },
+          type: { type: 'string' },
+          value: {}
+        },
+        additionalProperties: true
+      }
+    },
+    flow: {
+      type: 'array',
+      items: { $ref: '#/definitions/module' }
+    }
+  },
+  definitions: {
+    module: {
+      type: 'object',
+      required: ['id', 'module'],
+      properties: {
+        id: { anyOf: [{ type: 'integer' }, { type: 'string' }] },
+        module: { type: 'string' },
+        label: { type: 'string' },
+        parameters: { type: 'object' },
+        mapper: { type: 'object' },
+        metadata: { type: 'object' },
+        filter: { type: ['object', 'null'] },
+        routes: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['flow'],
+            properties: {
+              filter: { type: ['object', 'null'] },
+              flow: { type: 'array', items: { $ref: '#/definitions/module' } }
+            },
+            additionalProperties: true
+          }
+        },
+        onerror: {
+          type: 'array',
+          items: { $ref: '#/definitions/module' }
+        }
+      },
+      additionalProperties: true
+    }
+  },
+  additionalProperties: true
+};
+
+module.exports = schema;

--- a/src/services/blueprintExporter.js
+++ b/src/services/blueprintExporter.js
@@ -1,0 +1,8 @@
+function exportBlueprint(blueprint) {
+  if (!blueprint || typeof blueprint !== 'object') {
+    throw new Error('Invalid blueprint object');
+  }
+  return JSON.stringify(blueprint, null, 2);
+}
+
+module.exports = { exportBlueprint };

--- a/src/services/blueprintImporter.js
+++ b/src/services/blueprintImporter.js
@@ -1,0 +1,23 @@
+const schema = require('../schemas/makeBlueprintSchema');
+
+function basicValidate(obj) {
+  if (!obj || typeof obj !== 'object') return false;
+  if (typeof obj.name !== 'string') return false;
+  if (!Array.isArray(obj.flow)) return false;
+  return true;
+}
+
+function importBlueprint(jsonStr) {
+  let data;
+  try {
+    data = JSON.parse(jsonStr);
+  } catch (e) {
+    throw new Error('Invalid JSON');
+  }
+  if (!basicValidate(data)) {
+    throw new Error('Data does not conform to basic schema');
+  }
+  return data;
+}
+
+module.exports = { importBlueprint, schema };

--- a/tests/importExport.test.js
+++ b/tests/importExport.test.js
@@ -1,0 +1,27 @@
+const { importBlueprint } = require('../src/services/blueprintImporter');
+const { exportBlueprint } = require('../src/services/blueprintExporter');
+
+describe('blueprintImporter', () => {
+  test('parses valid blueprint JSON', () => {
+    const json = '{"name":"BP","flow":[]}';
+    const obj = importBlueprint(json);
+    expect(obj).toEqual({ name: 'BP', flow: [] });
+  });
+
+  test('throws on invalid JSON', () => {
+    expect(() => importBlueprint('not-json')).toThrow('Invalid JSON');
+  });
+
+  test('throws when required fields missing', () => {
+    expect(() => importBlueprint('{"name":"bp"}')).toThrow('Data does not conform to basic schema');
+  });
+});
+
+describe('blueprintExporter', () => {
+  test('serializes blueprint object', () => {
+    const obj = { name: 'BP', flow: [] };
+    const json = exportBlueprint(obj);
+    expect(JSON.parse(json)).toEqual(obj);
+    expect(json).toContain('\n');
+  });
+});


### PR DESCRIPTION
## Summary
- define JSON schema for Make blueprints
- create importer and exporter helpers
- add tests for importer and exporter
- document basic schema coverage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608436f75c83318d7c337da5b46f0e