### PR TITLE
Implement JSON logger

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const logger = require('./src/utils/logger');
 
 const srcDir = path.join(__dirname, 'src');
 const distDir = path.join(__dirname, 'dist');
@@ -46,4 +47,5 @@ output = output.replace(
 
 fs.writeFileSync(outputFile, output, 'utf-8');
 
-console.log('Build complete: ' + outputFile);
+logger.info('Build complete', { file: outputFile });
+

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,11 @@
+function emit(level, message, meta = {}) {
+  const entry = { timestamp: new Date().toISOString(), level, message, ...meta };
+  process.stdout.write(JSON.stringify(entry) + '\n');
+}
+
+module.exports = {
+  debug: (msg, meta) => emit('debug', msg, meta),
+  info: (msg, meta) => emit('info', msg, meta),
+  warn: (msg, meta) => emit('warn', msg, meta),
+  error: (msg, meta) => emit('error', msg, meta)
+};

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,0 +1,30 @@
+const logger = require('../src/utils/logger');
+
+describe('logger', () => {
+  let spy;
+  let output;
+
+  beforeEach(() => {
+    output = '';
+    spy = jest.spyOn(process.stdout, 'write').mockImplementation(str => {
+      output += str;
+    });
+    jest.useFakeTimers().setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  ['debug', 'info', 'warn', 'error'].forEach(level => {
+    test(`${level} outputs JSON line`, () => {
+      logger[level]('message', { extra: 1 });
+      const obj = JSON.parse(output);
+      expect(obj.level).toBe(level);
+      expect(obj.message).toBe('message');
+      expect(obj.extra).toBe(1);
+      expect(obj.timestamp).toBe('2020-01-01T00:00:00.000Z');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- create `src/utils/logger.js` with JSON-based logging
- swap `console.log` in `build.js` for logger
- add Jest tests for the logger

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860843fd6e88331b21f31996e827d87