### PR TITLE
Add Content Security Policy and nonce generation

### DIFF
--- a/docs/security_basics.md
+++ b/docs/security_basics.md
@@ -1,0 +1,13 @@
+# Security Basics (2.2.1)
+
+To guard against injection attacks, the application now ships with a strict Content Security Policy.
+The policy allows resources only from the same origin and permits web workers from `blob:` URLs:
+
+```html
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; worker-src blob:">
+```
+
+A small module `cspNonce.js` generates a random nonce on page load and adds it to any inline script tags.
+This prepares the code base for future CSP policies that require nonces.
+
+Verify the policy by opening DevTools. No CSP errors should appear in the console when loading the page.

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; worker-src blob:"/>
   <title>Erin's Coffee Grinder v7.0 - Enhanced</title>
   <link rel="stylesheet" href="styles/main.css"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.min.css"/>
@@ -71,6 +72,7 @@
 
   </div>
 
+  <script type="module" src="scripts/cspNonce.js"></script>
   <script type="module" src="scripts/main.js"></script>
 </body>
 </html>

--- a/src/scripts/cspNonce.js
+++ b/src/scripts/cspNonce.js
@@ -1,0 +1,10 @@
+export function applyCspNonce() {
+  const array = new Uint8Array(16);
+  window.crypto.getRandomValues(array);
+  const nonce = Array.from(array, b => b.toString(16).padStart(2, '0')).join('');
+  document.querySelectorAll('script:not([src])').forEach(script => {
+    script.setAttribute('nonce', nonce);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', applyCspNonce);


### PR DESCRIPTION
## Summary
- secure `index.html` with a CSP meta tag
- add a small module to generate nonces for inline scripts
- document the approach in `docs/security_basics.md`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860843bc99c83318277b0ae1c5966f0