### PR TITLE
Add basic Make.com API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Then execute the unit tests with:
 npm test
 ```
 
+## Make.com Integration
+The new `makeApiClient` module offers helper functions to deploy scenarios to the Make API. Use `deployScenario(token, blueprint)` to push a blueprint using an OAuth access token.
+
 ## Contributing
 Contributions are welcome! Fork the repository and create a feature branch
 from `main`. When you're ready, open a pull request. See

--- a/src/services/makeApiClient.js
+++ b/src/services/makeApiClient.js
@@ -1,0 +1,44 @@
+// Basic client for Make.com API interactions
+// Uses global fetch (Node 18+) with retry logic.
+// Not production-ready; meant as a starting point for Make integration.
+
+const DEFAULT_RETRIES = 3;
+const BASE_URL = 'https://api.make.com/v2';
+
+async function request(path, options = {}, retries = DEFAULT_RETRIES) {
+  const url = `${BASE_URL}${path}`;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url, options);
+      if (!res.ok) {
+        const text = await res.text();
+        const err = new Error(`Request failed: ${res.status}`);
+        err.status = res.status;
+        err.body = text;
+        throw err;
+      }
+      return res.json();
+    } catch (err) {
+      if (attempt === retries) throw err;
+      // simple exponential backoff
+      const wait = 2 ** attempt * 100;
+      await new Promise(r => setTimeout(r, wait));
+    }
+  }
+}
+
+async function deployScenario(token, blueprint) {
+  if (!token) throw new Error('Missing API token');
+  if (!blueprint) throw new Error('Missing blueprint data');
+  const options = {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(blueprint)
+  };
+  return request('/scenarios', options);
+}
+
+module.exports = { request, deployScenario };

--- a/tests/makeApiClient.test.js
+++ b/tests/makeApiClient.test.js
@@ -1,0 +1,31 @@
+const { request, deployScenario } = require('../src/services/makeApiClient');
+
+// Mock global fetch
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test('request retries on failure then succeeds', async () => {
+  const responses = [
+    Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve('err') }),
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) })
+  ];
+  global.fetch.mockImplementation(() => responses.shift());
+
+  const data = await request('/ping');
+  expect(data.ok).toBe(true);
+  expect(fetch).toHaveBeenCalledTimes(2);
+});
+
+test('deployScenario sends auth header', async () => {
+  global.fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ id: 1 }) });
+  const bp = { name: 'test', flow: [] };
+  await deployScenario('token123', bp);
+  const call = fetch.mock.calls[0];
+  expect(call[0]).toContain('/scenarios');
+  expect(call[1].headers.Authorization).toBe('Bearer token123');
+});


### PR DESCRIPTION
## Summary
- implement `makeApiClient` with retry logic and a `deployScenario` helper
- test new API client behaviour
- document Make.com integration in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609077ecac83319bad480e5caf1710