### PR TITLE
Fix fetch mock restoration

### DIFF
--- a/tests/makeApiClient.test.js
+++ b/tests/makeApiClient.test.js
@@ -1,12 +1,16 @@
 const { request, deployScenario } = require('../src/services/makeApiClient');
 
+let originalFetch;
+
 // Mock global fetch
 beforeEach(() => {
+  originalFetch = global.fetch;
   global.fetch = jest.fn();
 });
 
 afterEach(() => {
   jest.clearAllMocks();
+  global.fetch = originalFetch;
 });
 
 test('request retries on failure then succeeds', async () => {


### PR DESCRIPTION
## Summary
- capture the original `fetch` in `makeApiClient` test
- restore `fetch` after each test

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: network access denied)*

------
https://chatgpt.com/codex/tasks/task_e_686091f17ba0833192ee949b2c8dff24