### PR TITLE
Implement base validator, error handler and Husky lint hook

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
     node: true,
     jest: true
   },
-  extends: ['eslint:recommended'],
+  extends: ['eslint:recommended', 'plugin:sonarjs/recommended'],
+  plugins: ['sonarjs'],
   parserOptions: {
     ecmaVersion: 2021,
     sourceType: 'module'

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $1"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"'
+    exit 0
+  fi
+  readonly husky_version="1.0.0"
+  debug "husky version $husky_version"
+  if [ -f ~/.huskyrc ]; then
+    debug "~/.huskyrc found, sourcing..."
+    . ~/.huskyrc
+  fi
+  export readonly husky_skip_init=1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "jest",
     "lint": "eslint src/ tests/",
     "lint:fix": "eslint src/ tests/ --fix",
-    "format": "prettier --write src/ tests/"
+    "format": "prettier --write src/ tests/",
+    "prepare": "husky install"
   },
   "keywords": [
     "automation",
@@ -27,6 +28,7 @@
     "eslint-plugin-sonarjs": "^3.0.4",
     "jest": "^29.7.0",
     "prettier": "^3.6.2",
-    "rollup": "^4.44.0"
+    "rollup": "^4.44.0",
+    "husky": "^9.0.11"
   }
 }

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -1,0 +1,9 @@
+function handleError(message) {
+  if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+    window.alert(message);
+  } else {
+    console.error(message);
+  }
+}
+
+module.exports = { handleError };

--- a/src/validators/baseValidator.js
+++ b/src/validators/baseValidator.js
@@ -1,0 +1,12 @@
+const AjvLib = typeof window === 'undefined' ? require('ajv') : window.Ajv;
+
+function createValidator(options = {}) {
+  const defaults = {
+    allErrors: true,
+    verbose: true,
+    strict: false
+  };
+  return new AjvLib({ ...defaults, ...options });
+}
+
+module.exports = createValidator;

--- a/tests/baseValidator.test.js
+++ b/tests/baseValidator.test.js
@@ -1,0 +1,7 @@
+const createValidator = require('../src/validators/baseValidator');
+
+test('returns Ajv instance with defaults', () => {
+  const ajv = createValidator();
+  expect(typeof ajv.validate).toBe('function');
+  expect(ajv.opts.allErrors).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add a shared Ajv wrapper `baseValidator.js`
- provide a simple UI `errorHandler`
- enable `eslint-plugin-sonarjs` and Husky pre-commit hook
- add corresponding unit test

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run lint:fix` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686310d6b19883318ef9794954f0ff02