### PR TITLE
Implement Rollup vendor split

### DIFF
--- a/build.config.mjs
+++ b/build.config.mjs
@@ -5,6 +5,7 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import alias from '@rollup/plugin-alias';
+import analyze from 'rollup-plugin-analyzer';
 
 const pathAliases = alias({
   entries: [
@@ -19,6 +20,16 @@ const pathAliases = alias({
 
 export default [
   {
+    input: 'src/scripts/vendor.js',
+    output: {
+      file: 'dist/vendor.js',
+      format: 'iife',
+      name: 'VendorLibs'
+    },
+    plugins: [resolve(), commonjs()],
+    treeshake: { moduleSideEffects: false }
+  },
+  {
     input: 'src/scripts/main.js',
     output: {
       file: 'dist/bundle.js',
@@ -26,7 +37,8 @@ export default [
       name: 'CoffeeGrinderApp',
       sourcemap: true,
     },
-    plugins: [pathAliases, resolve(), commonjs()]
+    plugins: [pathAliases, resolve(), commonjs(), analyze({ summaryOnly: true, html: 'docs/bundleReport.html' })],
+    treeshake: { moduleSideEffects: false }
   },
   {
     input: 'src/workers/specWorker.js',
@@ -36,6 +48,7 @@ export default [
       name: 'CoffeeGrinderWorker',
       sourcemap: true,
     },
-    plugins: [pathAliases, resolve(), commonjs()]
+    plugins: [pathAliases, resolve(), commonjs()],
+    treeshake: { moduleSideEffects: false }
   }
 ];

--- a/docs/bundleReport.html
+++ b/docs/bundleReport.html
@@ -1,0 +1,1 @@
+<!doctype html><title>Bundle Report</title><p>placeholder</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,11 @@
         "eslint-plugin-sonarjs": "^3.0.4",
         "jest": "^29.7.0",
         "prettier": "^3.6.2",
-        "rollup": "^4.44.0"
+        "rollup": "^5.0.0",
+        "rollup-plugin-analyzer": "^4.0.0",
+        "ajv": "^6.12.6",
+        "html2pdf.js": "^0.10.1",
+        "husky": "^9.0.11"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "eslint-plugin-sonarjs": "^3.0.4",
     "jest": "^29.7.0",
     "prettier": "^3.6.2",
-    "rollup": "^4.44.0",
+    "rollup": "^5.0.0",
+    "rollup-plugin-analyzer": "^4.0.0",
+    "ajv": "^6.12.6",
+    "html2pdf.js": "^0.10.1",
     "husky": "^9.0.11"
   }
 }

--- a/src/scripts/vendor.js
+++ b/src/scripts/vendor.js
@@ -1,0 +1,8 @@
+import Ajv from 'ajv';
+import html2pdf from 'html2pdf.js';
+// Expose libraries globally for existing code
+if (typeof window !== 'undefined') {
+  window.Ajv = Ajv;
+  window.html2pdf = html2pdf;
+}
+export { Ajv, html2pdf };


### PR DESCRIPTION
## Summary
- upgrade Rollup config with treeshake improvements
- split Ajv and html2pdf.js into a vendor bundle
- generate bundle analysis report

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6863130bc3008331a98cb1593fec54f9