### PR TITLE
Add NODE_ENV replacement in Rollup builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Then open your browser at `http://localhost:8080`.
 ### Building for Distribution
 Build artifacts are generated in `dist/`:
 
-1. Bundle scripts with Rollup:
+1. Bundle scripts with Rollup (this command sets `NODE_ENV=production` so CDN scripts load correctly):
    ```bash
    npm run build
    ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.html",
   "scripts": {
     "dev": "python -m http.server 8080 --directory src",
-    "build": "rollup -c build.config.mjs",
+    "build": "NODE_ENV=production rollup -c rollup.prod.config.mjs",
     "serve": "npx serve dist -p 8080",
     "test": "jest",
     "lint": "eslint src/ tests/",
@@ -24,6 +24,7 @@
     "@rollup/plugin-alias": "^5.0.0",
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-replace": "^5.0.0",
     "eslint": "^9.0.0",
     "@eslint/js": "^9.0.0",
     "eslint-plugin-sonarjs": "^3.0.4",

--- a/rollup.dev.config.mjs
+++ b/rollup.dev.config.mjs
@@ -1,0 +1,56 @@
+/**
+ * Rollup development config with source maps and env replacement.
+ */
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import alias from '@rollup/plugin-alias';
+import analyze from 'rollup-plugin-analyzer';
+import replace from '@rollup/plugin-replace';
+
+const pathAliases = alias({
+  entries: [
+    { find: '@components', replacement: 'src/components' },
+    { find: '@services', replacement: 'src/services' },
+    { find: '@workers', replacement: 'src/workers' },
+    { find: '@validators', replacement: 'src/validators' },
+    { find: '@utils', replacement: 'src/utils' },
+    { find: '@templates', replacement: 'src/templates' }
+  ]
+});
+
+const envReplace = replace({ preventAssignment: true, 'window.NODE_ENV': JSON.stringify(process.env.NODE_ENV) });
+
+export default [
+  {
+    input: 'src/scripts/vendor.js',
+    output: {
+      file: 'dist/vendor.js',
+      format: 'iife',
+      name: 'VendorLibs'
+    },
+    plugins: [envReplace, resolve(), commonjs()],
+    treeshake: { moduleSideEffects: false }
+  },
+  {
+    input: 'src/scripts/main.js',
+    output: {
+      file: 'dist/bundle.js',
+      format: 'iife',
+      name: 'CoffeeGrinderApp',
+      sourcemap: true,
+    },
+    plugins: [envReplace, pathAliases, resolve(), commonjs(), analyze({ summaryOnly: true, html: 'docs/bundleReport.html' })],
+    treeshake: { moduleSideEffects: false }
+  },
+  {
+    input: 'src/workers/specWorker.js',
+    output: {
+      file: 'dist/worker.bundle.js',
+      format: 'iife',
+      name: 'CoffeeGrinderWorker',
+      sourcemap: true,
+    },
+    plugins: [envReplace, pathAliases, resolve(), commonjs()],
+    treeshake: { moduleSideEffects: false }
+  }
+];

--- a/rollup.prod.config.mjs
+++ b/rollup.prod.config.mjs
@@ -1,0 +1,56 @@
+/**
+ * Rollup production config with env replacement and no source maps.
+ */
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import alias from '@rollup/plugin-alias';
+import analyze from 'rollup-plugin-analyzer';
+import replace from '@rollup/plugin-replace';
+
+const pathAliases = alias({
+  entries: [
+    { find: '@components', replacement: 'src/components' },
+    { find: '@services', replacement: 'src/services' },
+    { find: '@workers', replacement: 'src/workers' },
+    { find: '@validators', replacement: 'src/validators' },
+    { find: '@utils', replacement: 'src/utils' },
+    { find: '@templates', replacement: 'src/templates' }
+  ]
+});
+
+const envReplace = replace({ preventAssignment: true, 'window.NODE_ENV': JSON.stringify(process.env.NODE_ENV) });
+
+export default [
+  {
+    input: 'src/scripts/vendor.js',
+    output: {
+      file: 'dist/vendor.js',
+      format: 'iife',
+      name: 'VendorLibs'
+    },
+    plugins: [envReplace, resolve(), commonjs()],
+    treeshake: { moduleSideEffects: false }
+  },
+  {
+    input: 'src/scripts/main.js',
+    output: {
+      file: 'dist/bundle.js',
+      format: 'iife',
+      name: 'CoffeeGrinderApp',
+      sourcemap: false,
+    },
+    plugins: [envReplace, pathAliases, resolve(), commonjs(), analyze({ summaryOnly: true, html: 'docs/bundleReport.html' })],
+    treeshake: { moduleSideEffects: false }
+  },
+  {
+    input: 'src/workers/specWorker.js',
+    output: {
+      file: 'dist/worker.bundle.js',
+      format: 'iife',
+      name: 'CoffeeGrinderWorker',
+      sourcemap: false,
+    },
+    plugins: [envReplace, pathAliases, resolve(), commonjs()],
+    treeshake: { moduleSideEffects: false }
+  }
+];


### PR DESCRIPTION
## Summary
- inject `window.NODE_ENV` using `@rollup/plugin-replace`
- split Rollup configs into `rollup.dev.config.mjs` and `rollup.prod.config.mjs`
- set `NODE_ENV=production` in the build script
- document production environment for builds

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863224a79a88331a2a24cf443c8fd50