### PR TITLE
Add connection remap support

### DIFF
--- a/src/services/blueprintImporter.js
+++ b/src/services/blueprintImporter.js
@@ -7,7 +7,7 @@ function basicValidate(obj) {
   return true;
 }
 
-function importBlueprint(jsonStr) {
+function importBlueprint(jsonStr, options = {}) {
   let data;
   try {
     data = JSON.parse(jsonStr);
@@ -17,6 +17,50 @@ function importBlueprint(jsonStr) {
   if (!basicValidate(data)) {
     throw new Error('Data does not conform to basic schema');
   }
+  if (options.remapConnections && typeof options.remapConnections === 'object') {
+    const map = options.remapConnections;
+
+    if (Array.isArray(data.connections)) {
+      data.connections.forEach(conn => {
+        if (Object.prototype.hasOwnProperty.call(map, conn.id)) {
+          conn.id = map[conn.id];
+        }
+      });
+    }
+
+    const walk = flow => {
+      if (!Array.isArray(flow)) return;
+      flow.forEach(mod => {
+        if (mod.parameters) {
+          if (
+            Object.prototype.hasOwnProperty.call(
+              map,
+              mod.parameters.__IMTCONN__
+            )
+          ) {
+            mod.parameters.__IMTCONN__ = map[mod.parameters.__IMTCONN__];
+          }
+          if (
+            Object.prototype.hasOwnProperty.call(
+              map,
+              mod.parameters.__IMTHOOK__
+            )
+          ) {
+            mod.parameters.__IMTHOOK__ = map[mod.parameters.__IMTHOOK__];
+          }
+        }
+        if (Array.isArray(mod.routes)) {
+          mod.routes.forEach(route => walk(route.flow));
+        }
+        if (Array.isArray(mod.onerror)) {
+          walk(mod.onerror);
+        }
+      });
+    };
+
+    walk(data.flow);
+  }
+
   return data;
 }
 

--- a/tests/importExport.test.js
+++ b/tests/importExport.test.js
@@ -15,6 +15,28 @@ describe('blueprintImporter', () => {
   test('throws when required fields missing', () => {
     expect(() => importBlueprint('{"name":"bp"}')).toThrow('Data does not conform to basic schema');
   });
+
+  test('remaps connection ids when option provided', () => {
+    const bp = {
+      name: 'BP',
+      connections: [{ id: 1, type: 'http' }],
+      flow: [
+        { id: '1', module: 'a', parameters: { __IMTCONN__: 1 } },
+        {
+          id: '2',
+          module: 'b',
+          routes: [
+            { flow: [{ id: '3', module: 'c', parameters: { __IMTHOOK__: 1 } }] }
+          ]
+        }
+      ]
+    };
+    const json = JSON.stringify(bp);
+    const obj = importBlueprint(json, { remapConnections: { 1: 99 } });
+    expect(obj.connections[0].id).toBe(99);
+    expect(obj.flow[0].parameters.__IMTCONN__).toBe(99);
+    expect(obj.flow[1].routes[0].flow[0].parameters.__IMTHOOK__).toBe(99);
+  });
 });
 
 describe('blueprintExporter', () => {


### PR DESCRIPTION
## Summary
- allow `importBlueprint` to remap connection IDs
- update nested flows when remapping
- test remap option in importer

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864187350a883318457ee921a103307