### PR TITLE
Add Ajv schema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "jest": "^29.7.0",
     "prettier": "^3.6.2",
     "rollup": "^4.44.0"
+  },
+  "dependencies": {
+    "ajv": "^8.12.0"
   }
 }

--- a/src/services/blueprintImporter.js
+++ b/src/services/blueprintImporter.js
@@ -1,11 +1,8 @@
 const schema = require('../schemas/makeBlueprintSchema');
+const createValidator = require('../validators/baseValidator');
 
-function basicValidate(obj) {
-  if (!obj || typeof obj !== 'object') return false;
-  if (typeof obj.name !== 'string') return false;
-  if (!Array.isArray(obj.flow)) return false;
-  return true;
-}
+const ajv = createValidator();
+const validate = ajv.compile(schema);
 
 function importBlueprint(jsonStr, options = {}) {
   let data;
@@ -14,8 +11,12 @@ function importBlueprint(jsonStr, options = {}) {
   } catch (e) {
     throw new Error('Invalid JSON');
   }
-  if (!basicValidate(data)) {
-    throw new Error('Data does not conform to basic schema');
+  if (!validate(data)) {
+    const err = new Error(
+      'Data does not match schema: ' + ajv.errorsText(validate.errors)
+    );
+    err.validationErrors = validate.errors;
+    throw err;
   }
   if (options.remapConnections && typeof options.remapConnections === 'object') {
     const map = options.remapConnections;

--- a/tests/importExport.test.js
+++ b/tests/importExport.test.js
@@ -13,7 +13,16 @@ describe('blueprintImporter', () => {
   });
 
   test('throws when required fields missing', () => {
-    expect(() => importBlueprint('{"name":"bp"}')).toThrow('Data does not conform to basic schema');
+    expect(() => importBlueprint('{"name":"bp"}')).toThrow(/Data does not match schema/);
+  });
+
+  test('provides Ajv error details on validation failure', () => {
+    try {
+      importBlueprint('{"name":123,"flow":{}}');
+    } catch (err) {
+      expect(err.message).toMatch(/Data does not match schema/);
+      expect(Array.isArray(err.validationErrors)).toBe(true);
+    }
   });
 
   test('remaps connection ids when option provided', () => {


### PR DESCRIPTION
## Summary
- depend on Ajv
- validate blueprints against `makeBlueprintSchema` using Ajv
- test Ajv validation errors for blueprint importing

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645e425650833183d14d5e6aa923c3