### PR TITLE
Update README with Ajv dependency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ After cloning the repository, install all dependencies:
 npm ci
 ```
 This installs dev tools such as **Jest** and **ESLint** required for testing and linting.
+The JSON schema validator **Ajv** is also installed automatically.
 
 ### Running Locally
 You can serve the `src` directory using a simple HTTP server or the provided npm script:
@@ -48,6 +49,7 @@ Then open your browser at `http://localhost:8080`.
 ### Development
 - Edit source files in `src/`.
 - The app will load the modularized CSS and JS files.
+- The project relies on **Ajv** for JSON schema validation; it is installed automatically when you run `npm install` or `npm ci`.
 - Start a local dev server with:
    ```bash
    npm run dev


### PR DESCRIPTION
## Summary
- mention Ajv installation under Getting Started
- clarify Ajv is installed automatically in Development section

## Testing
- `npm run lint`
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686460b2f4dc8331a5af37850be59ab3