### PR TITLE
Implement DOMPurify sanitization

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/mode/javascript/javascript.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.12.0/ajv7.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sorttable/2.1.0/sorttable.min.js"></script>
 </head>
 <body>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -222,7 +222,8 @@ function handleWorkerMessage(e) {
     const { html, warnings, processedModules: pm } = e.data;
     processedModules = pm; // Store processed data for export
 
-    outArea.innerHTML = html;
+    const safeHtml = window.DOMPurify ? window.DOMPurify.sanitize(html) : html;
+    outArea.innerHTML = safeHtml;
     if (warnings && warnings.length > 0) {
         showWarning(parseWarn, 'Processing Warnings:\n- ' + warnings.join('\n- '));
     } else {

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -1,5 +1,16 @@
+let DOMPurify = null;
+if (typeof window !== 'undefined' && window.DOMPurify) {
+  DOMPurify = window.DOMPurify;
+}
+
 function sanitizeForHTML(str) {
   if (!str) return '';
+  if (DOMPurify) {
+    return DOMPurify.sanitize(String(str), {
+      ALLOWED_TAGS: [],
+      ALLOWED_ATTR: []
+    });
+  }
   return String(str)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/src/workers/specWorker.js
+++ b/src/workers/specWorker.js
@@ -4,15 +4,20 @@ let sanitizeForHTML, formatJson;
 if (typeof module !== 'undefined' && module.exports) {
   ({ sanitizeForHTML, formatJson } = require('../scripts/utils'));
 } else {
-  sanitizeForHTML = str => {
-    if (!str) return '';
-    return String(str)
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#039;');
-  };
+  if (self.DOMPurify) {
+    sanitizeForHTML = str =>
+      self.DOMPurify.sanitize(String(str || ''), { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
+  } else {
+    sanitizeForHTML = str => {
+      if (!str) return '';
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+    };
+  }
 
   formatJson = data => {
     try {


### PR DESCRIPTION
## Summary
- include DOMPurify from CDN in `index.html`
- use DOMPurify in `sanitizeForHTML` when available
- sanitize worker output before inserting into the DOM
- support DOMPurify inside `specWorker`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68679f14930483318eac44bafeece8e3